### PR TITLE
Give explanations for disabled actions in context menu.

### DIFF
--- a/org.neo4j.neoclipse/src/main/java/org/neo4j/neoclipse/view/NeoGraphMenu.java
+++ b/org.neo4j.neoclipse/src/main/java/org/neo4j/neoclipse/view/NeoGraphMenu.java
@@ -294,13 +294,25 @@ public class NeoGraphMenu
         gc.fillRectangle( image.getBounds() );
         gc.dispose();
         RELTYPES_DEFAULT_IMG = ImageDescriptor.createFromImage( image );
-        Action dummyAction = new Action( "(disabled)" )
+        Action dummyAction = new Action( "Select two nodes to create a relationship between them" )
         {
         };
         dummyAction.setEnabled( false );
         addRelMenuMgrFake.add( dummyAction );
+        dummyAction = new Action( "Select at least one node to create an end node" )
+        {
+        };
+        dummyAction.setEnabled( false );
         addOutNodeMenuMgrFake.add( dummyAction );
+        dummyAction = new Action( "Select at least one node to create a start node" )
+        {
+        };
+        dummyAction.setEnabled( false );
         addInNodeMenuMgrFake.add( dummyAction );
+        dummyAction = new Action( "Select a single node to add a loop" )
+        {
+        };
+        dummyAction.setEnabled( false );
         addLoopMenuMgrFake.add( dummyAction );
     }
 


### PR DESCRIPTION
When right clicking a node in the graph view and only a single node is
selected, the "Create a relationship between two existing nodes" submenu
reads "(disabled)" and is greyed out. It's not immediately obvious (at
least not to everyone) that the action needs two selected nodes. As the
action is greyed out and disabled, the text "(disabled)" is redundant
and can be put to better use. This patch replaces the text with "Select
two nodes to create a relationship between them", which gives a clear
indication why the action is greyed out. The other actions are changed
accordingly.

Hey @nawroth, according to `git log` you're the main developer for Neoclipse, so I'm pinging you on this. Patch is tested and working. Let me know if you think this is a good idea.
