### PR TITLE
Config cleanup and added missing license headers

### DIFF
--- a/org.neo4j.neoclipse.doc/.classpath
+++ b/org.neo4j.neoclipse.doc/.classpath
@@ -1,15 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/jdk1.6.0_29"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="con" path="org.maven.ide.eclipse.MAVEN2_CLASSPATH_CONTAINER"/>
-	<classpathentry kind="lib" path="/org.neo4j.neoclipse/lib/geronimo-jta_1.1_spec-1.1.1.jar"/>
-	<classpathentry kind="lib" path="/org.neo4j.neoclipse/lib/lucene-core-3.1.0.jar"/>
-	<classpathentry kind="lib" path="/org.neo4j.neoclipse/lib/neo4j-graph-algo-1.6.M02.jar"/>
-	<classpathentry kind="lib" path="/org.neo4j.neoclipse/lib/neo4j-jmx-1.6.M02.jar"/>
-	<classpathentry kind="lib" path="/org.neo4j.neoclipse/lib/neo4j-kernel-1.6.M02.jar"/>
-	<classpathentry kind="lib" path="/org.neo4j.neoclipse/lib/neo4j-lucene-index-1.6.M02.jar"/>
-	<classpathentry kind="lib" path="/org.neo4j.neoclipse/lib/neo4j-rest-graphdb-1.6-SNAPSHOT.jar" sourcepath="/neo4j-rest-graphdb"/>
-	<classpathentry kind="lib" path="/org.neo4j.neoclipse/lib/neo4j-udc-1.6.M02.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/org.neo4j.neoclipse.doc/.project
+++ b/org.neo4j.neoclipse.doc/.project
@@ -25,14 +25,8 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
-		<buildCommand>
-			<name>org.maven.ide.eclipse.maven2Builder</name>
-			<arguments>
-			</arguments>
-		</buildCommand>
 	</buildSpec>
 	<natures>
-		<nature>org.maven.ide.eclipse.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.wst.common.project.facet.core.nature</nature>

--- a/org.neo4j.neoclipse.doc/pom.xml
+++ b/org.neo4j.neoclipse.doc/pom.xml
@@ -5,11 +5,12 @@
   <parent>
     <artifactId>neoclipse</artifactId>
     <groupId>org.neo4j</groupId>
-    <version>1.6</version>
+    <version>1.8-SNAPSHOT</version>
+    <relativePath>..</relativePath>
   </parent>
   <groupId>org.neo4j</groupId>
   <artifactId>org.neo4j.neoclipse.doc</artifactId>
-  <version>1.6</version>
+  <version>1.8-SNAPSHOT</version>
   <name>Neoclipse Documentation Plugin</name>
-  <packaging>eclipse-plugin</packaging>
+  <!--  packaging>eclipse-plugin</packaging -->
 </project>

--- a/org.neo4j.neoclipse/.project
+++ b/org.neo4j.neoclipse/.project
@@ -15,14 +15,8 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
-		<buildCommand>
-			<name>org.maven.ide.eclipse.maven2Builder</name>
-			<arguments>
-			</arguments>
-		</buildCommand>
 	</buildSpec>
 	<natures>
-		<nature>org.maven.ide.eclipse.maven2Nature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.wst.common.project.facet.core.nature</nature>

--- a/org.neo4j.neoclipse/pom.xml
+++ b/org.neo4j.neoclipse/pom.xml
@@ -5,38 +5,16 @@
   <parent>
     <artifactId>neoclipse</artifactId>
     <groupId>org.neo4j</groupId>
-    <version>1.6</version>
+    <version>1.8-SNAPSHOT</version>
+    <relativePath>..</relativePath>
   </parent>
   <groupId>org.neo4j</groupId>
   <artifactId>org.neo4j.neoclipse</artifactId>
-  <version>1.6</version>
+  <version>1.8-SNAPSHOT</version>
   <name>Neoclipse</name>
 
   <properties>
     <license-text.header>ApacheLicense-2.0-header.txt</license-text.header>
   </properties>
 
-  <dependencies>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.neo4j</groupId>
-      <artifactId>neo4j</artifactId>
-      <version>1.6.M03</version>
-      <type>pom</type>
-      <scope>compile</scope>
-    </dependency>
-  </dependencies>
-  <build>
-    <resources>
-      <resource>
-        <directory>${basedir}</directory>
-        <includes>
-          <include>plugin.xml</include>
-        </includes>
-      </resource>
-    </resources>
-  </build>
 </project>

--- a/org.neo4j.neoclipse/src/main/java/org/neo4j/neoclipse/connection/actions/ForceStartHandler.java
+++ b/org.neo4j.neoclipse/src/main/java/org/neo4j/neoclipse/connection/actions/ForceStartHandler.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to Neo Technology under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Neo Technology licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.neo4j.neoclipse.connection.actions;
 
 import org.neo4j.neoclipse.Activator;

--- a/org.neo4j.neoclipse/src/main/java/org/neo4j/neoclipse/editor/BaseWrapper.java
+++ b/org.neo4j.neoclipse/src/main/java/org/neo4j/neoclipse/editor/BaseWrapper.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to Neo Technology under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Neo Technology licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.neo4j.neoclipse.editor;
 
 import java.io.Serializable;

--- a/org.neo4j.neoclipse/src/main/java/org/neo4j/neoclipse/editor/CypherResultSet.java
+++ b/org.neo4j.neoclipse/src/main/java/org/neo4j/neoclipse/editor/CypherResultSet.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to Neo Technology under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Neo Technology licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.neo4j.neoclipse.editor;
 
 import java.io.Serializable;

--- a/org.neo4j.neoclipse/src/main/java/org/neo4j/neoclipse/editor/NodeWrapper.java
+++ b/org.neo4j.neoclipse/src/main/java/org/neo4j/neoclipse/editor/NodeWrapper.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to Neo Technology under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Neo Technology licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.neo4j.neoclipse.editor;
 
 import java.util.ArrayList;

--- a/org.neo4j.neoclipse/src/main/java/org/neo4j/neoclipse/editor/RelationshipWrapper.java
+++ b/org.neo4j.neoclipse/src/main/java/org/neo4j/neoclipse/editor/RelationshipWrapper.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to Neo Technology under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Neo Technology licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.neo4j.neoclipse.editor;
 
 

--- a/org.neo4j.neoclipse/src/main/java/org/neo4j/neoclipse/editor/SqlEditorView.java
+++ b/org.neo4j.neoclipse/src/main/java/org/neo4j/neoclipse/editor/SqlEditorView.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to Neo Technology under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Neo Technology licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.neo4j.neoclipse.editor;
 
 import java.io.File;

--- a/org.neo4j.neoclipse/src/main/java/org/neo4j/neoclipse/util/DataExportUtils.java
+++ b/org.neo4j.neoclipse/src/main/java/org/neo4j/neoclipse/util/DataExportUtils.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to Neo Technology under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Neo Technology licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.neo4j.neoclipse.util;
 
 import java.io.BufferedWriter;

--- a/org.neo4j.neoclipse/src/main/java/org/neo4j/neoclipse/util/ImageUtil.java
+++ b/org.neo4j.neoclipse/src/main/java/org/neo4j/neoclipse/util/ImageUtil.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to Neo Technology under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Neo Technology licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.neo4j.neoclipse.util;
 
 import java.net.URL;

--- a/org.neo4j.neoclipse/src/main/java/org/neo4j/neoclipse/util/TextUtil.java
+++ b/org.neo4j.neoclipse/src/main/java/org/neo4j/neoclipse/util/TextUtil.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to Neo Technology under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Neo Technology licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.neo4j.neoclipse.util;
 
 /**

--- a/org.neo4j.neoclipse/src/main/java/org/neo4j/neoclipse/util/URLUtil.java
+++ b/org.neo4j.neoclipse/src/main/java/org/neo4j/neoclipse/util/URLUtil.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to Neo Technology under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Neo Technology licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.neo4j.neoclipse.util;
 
 /*

--- a/pom.xml
+++ b/pom.xml
@@ -5,33 +5,16 @@
   <parent>
     <groupId>org.neo4j.build</groupId>
     <artifactId>parent-central</artifactId>
-    <version>25</version>
+    <version>35</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.neo4j</groupId>
   <artifactId>neoclipse</artifactId>
   <name>Neoclipse Project</name>
-  <version>1.6</version>
+  <version>1.8-SNAPSHOT</version>
   <packaging>pom</packaging>
   <modules>
     <module>org.neo4j.neoclipse</module>
     <module>org.neo4j.neoclipse.doc</module>
   </modules>
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>bundle-manifest</id>
-            <phase>none</phase>
-            <goals>
-              <goal>manifest</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
 </project>


### PR DESCRIPTION
Essentially removed maven references that makes Eclipse unhappy anyhow.
Added missing license headers.

This makes the project look good in Juno (4.2).

But I still can't launch the application, which Eclipse version should I build it against? (the plugin.xml file says 3.4, but that's clearly not the case.)
