### PR TITLE
Drop support for MacOS X Carbon UI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,11 +58,6 @@
               </environment>
               <environment>
                 <os>macosx</os>
-                <ws>carbon</ws>
-                <arch>x86</arch>
-              </environment>
-              <environment>
-                <os>macosx</os>
                 <ws>cocoa</ws>
                 <arch>x86</arch>
               </environment>

--- a/repository/neoclipse.product
+++ b/repository/neoclipse.product
@@ -289,7 +289,6 @@ conditions in this Agreement.
       <plugin id="org.eclipse.platform"/>
       <plugin id="org.eclipse.search"/>
       <plugin id="org.eclipse.swt"/>
-      <plugin id="org.eclipse.swt.carbon.macosx" fragment="true"/>
       <plugin id="org.eclipse.swt.cocoa.macosx" fragment="true"/>
       <plugin id="org.eclipse.swt.cocoa.macosx.x86_64" fragment="true"/>
       <plugin id="org.eclipse.swt.gtk.hpux.ia64_32" fragment="true"/>
@@ -302,7 +301,6 @@ conditions in this Agreement.
       <plugin id="org.eclipse.team.ui"/>
       <plugin id="org.eclipse.text"/>
       <plugin id="org.eclipse.ui"/>
-      <plugin id="org.eclipse.ui.carbon" fragment="true"/>
       <plugin id="org.eclipse.ui.cheatsheets"/>
       <plugin id="org.eclipse.ui.cocoa" fragment="true"/>
       <plugin id="org.eclipse.ui.console"/>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -79,7 +79,6 @@
                     <globmapper from="*" to="linux/gtk/ppc64/neoclipse-${project.version}/*"/>
                     <globmapper from="*" to="linux/gtk/x86/neoclipse-${project.version}/*"/>
                     <globmapper from="*" to="linux/gtk/x86_64/neoclipse-${project.version}/*"/>
-                    <globmapper from="*" to="macosx/carbon/x86/neoclipse-${project.version}/*"/>
                     <globmapper from="*" to="macosx/cocoa/x86/neoclipse-${project.version}/*"/>
                     <globmapper from="*" to="macosx/cocoa/x86_64/neoclipse-${project.version}/*"/>
                     <globmapper from="*" to="win32/win32/x86/neoclipse-${project.version}/*"/>


### PR DESCRIPTION
According to Anders Nawroth [1] and list of available downloads [2],
these builds aren't supported any more.

[1] https://github.com/neo4j-contrib/neoclipse/pull/53#issuecomment-27428059
[2] https://github.com/neo4j-contrib/neoclipse/blob/master/README.asciidoc#neoclipse-for-neo4j-191
